### PR TITLE
[HOTFIX] DiaryViewer title error _ ECH-146

### DIFF
--- a/echog/NetworkFeatureKit/Sources/NetworkFeatureKit/Diary/Model/DiaryListDTO.swift
+++ b/echog/NetworkFeatureKit/Sources/NetworkFeatureKit/Diary/Model/DiaryListDTO.swift
@@ -19,7 +19,7 @@ public struct DiaryContent: Decodable, Hashable, Sendable {
     public let id: UUID
     public var title: String
     public var content: String
-    let createdAt: String
+    public let createdAt: String
     public var createdDate: Date? {
         let formatter = DateFormatter()
         

--- a/echog/echog/Presentation/Diary/DiaryViewerViewController.swift
+++ b/echog/echog/Presentation/Diary/DiaryViewerViewController.swift
@@ -119,13 +119,13 @@ class DiaryViewerViewController: UIViewController, PopUpProtocol, ToastProtocol 
         }
         
         if let diary = state.diary {
-            titleBarLabel.text = diary.formattedDate
+            titleBarLabel.text = diary.createdAt
             titleLabel.text = diary.title
             contentsLabel.text = diary.content
         }
         
         if state.isDiaryUpdated == .success, let diary = state.diary {
-            titleBarLabel.text = diary.formattedDate
+            titleBarLabel.text = diary.createdAt
             titleLabel.text = diary.title
             contentsLabel.text = diary.content
         }


### PR DESCRIPTION
## 📚 작업한 일
- 매번 title bar에 당일만 나오는 오류 수정


## 🔥 설명
- Diary를 새로 생성할 때, formattedDate는 get-only라서 해당 값을 새로운 createdAt에 넘겨주고 있었는데 정작 titleBar에서는 formattedDate를 불러 createdDate 값은 없는 DiaryContent다 보니, 매번 Date() 값을 formatter에 넣어 생긴 문제였다. 
```swift
public struct DiaryContent: Decodable, Hashable, Sendable {
    public let id: UUID
    public var title: String
    public var content: String
    public let createdAt: String
    public var createdDate: Date? {
        let formatter = DateFormatter()
        
        formatter.locale = Locale(identifier: "ko_KR")
        // 시간대 정보 없이 소수점 이하 6자리까지 처리하는 포맷
        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
        // 만약 시간대 정보 없이 로컬 타임존으로 해석하고 싶다면:
        formatter.timeZone = TimeZone.current
        
        return formatter.date(from: createdAt)
    }
    public var formattedDate: String {
        let formatter = DateFormatter()
        
        formatter.locale = Locale(identifier: "ko_KR")
        formatter.dateFormat = "MM월 dd일 EEEE"
        
        return formatter.string(from: createdDate ?? Date())
    }
    
    public init(id: UUID, title: String, content: String, createdAt: String) {
        self.id = id
        self.title = title
        self.content = content
        self.createdAt = createdAt
    }
    
    public func hash(into hasher: inout Hasher) {
        hasher.combine(id)
    }
    
    public static func == (lhs: DiaryContent, rhs: DiaryContent) -> Bool {
        return lhs.id == rhs.id
    }
}

```