### PR TITLE
[HOTFIX] Diary viewer upload error _ ECH-151

### DIFF
--- a/echog/echog.xcodeproj/project.pbxproj
+++ b/echog/echog.xcodeproj/project.pbxproj
@@ -980,7 +980,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.traum.marchen.echog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1009,7 +1009,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.traum.marchen.echog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/echog/echog/Presentation/Diary/DiaryEditorViewController.swift
+++ b/echog/echog/Presentation/Diary/DiaryEditorViewController.swift
@@ -140,7 +140,7 @@ class DiaryEditorViewController: UIViewController, View, ToastProtocol {
     
     private func render(_ state: DiaryReducer.State) {
         if state.isNewDiaryUploadSuccess == .success {
-//            self.showToast(icon: .colorCheck, message: "일기가 저장되었어요.")
+            self.showToast(icon: .colorCheck, message: "일기가 저장되었어요.")
             store.dispatch(.presentDiaryList(page: 0))
         } else if state.isNewDiaryUploadSuccess == .failure {
             self.showToast(icon: .colorXmark, message: "저장에 실패했어요.")
@@ -148,7 +148,7 @@ class DiaryEditorViewController: UIViewController, View, ToastProtocol {
 //        
         if state.isDiaryUpdated == .success {
             store.dispatch(.presentDiaryList(page: 0))
-//            self.showToast(icon: .colorCheck, message: "일기가 저장되었어요.")
+            self.showToast(icon: .colorCheck, message: "일기가 저장되었어요.")
         } else if state.isDiaryUpdated == .failure {
             self.showToast(icon: .colorXmark, message: "저장에 실패했어요.")
         }
@@ -156,7 +156,7 @@ class DiaryEditorViewController: UIViewController, View, ToastProtocol {
         if let diary = state.diary {
             self.titleTextField.text = diary.title
             self.contentsTextView.text = diary.content
-            self.titleLabel.text = diary.formattedDate
+            self.titleLabel.text = diary.createdAt
         }
     }
     

--- a/echog/echog/Presentation/Diary/DiaryReducer.swift
+++ b/echog/echog/Presentation/Diary/DiaryReducer.swift
@@ -135,7 +135,7 @@ struct DiaryReducer: ReducerProtocol {
     }
     
     func reduce(state: State, mutation: Mutation) -> State {
-        var newState = state
+        var newState = State()
         
         switch mutation {
         case .presentDiaryList(let list, let page, let totalPages):
@@ -146,16 +146,12 @@ struct DiaryReducer: ReducerProtocol {
             }
             newState.totalPage = totalPages
         case .newDiaryCreateSuccess:
-            newState.diaryList = [:]
             newState.shouldLoadSnapshot = true
             newState.isNewDiaryUploadSuccess = .success
         case .newDiaryCreateFailure:
             newState.isNewDiaryUploadSuccess = .failure
         case .diaryUpdateSuccess(let title, let content):
-            newState.diary?.title = title
-            newState.diary?.content = content
-            newState.diaryList = [:]
-            newState.currentPage = 0
+            newState.diary = DiaryContent(id: state.diary?.id ?? UUID(), title: title, content: content, createdAt: state.diary?.createdAt ?? "")
             newState.shouldLoadSnapshot = true
             delegate?.popViewController()
         case .diaryUpdateFailure:
@@ -165,7 +161,6 @@ struct DiaryReducer: ReducerProtocol {
             newState.isDiaryDeleted = .failure
             newState.shouldLoadSnapshot = false
         case .deleteDiarySuccess:
-            newState.diaryList = [:]
             newState.shouldLoadSnapshot = true
             newState.isDiaryDeleted = .success
             delegate?.popViewController()
@@ -173,9 +168,10 @@ struct DiaryReducer: ReducerProtocol {
             newState.diary = DiaryContent(id: id, title: title, content: content, createdAt: date)
             delegate?.pushDiaryViewerViewController()
         case .popPage:
-            newState.diary = nil
             delegate?.popViewController()
         case .updateDiaryList(list: let list, page: let page):
+            newState = state
+            
             list.forEach { diary in
                 let sectionIdentifier = sectionIdentifier(for: diary)
                 if let index = newState.diaryList[sectionIdentifier]?.firstIndex(where: { $0.id == diary.id }) {

--- a/echog/echog/Presentation/Diary/DiaryViewerViewController.swift
+++ b/echog/echog/Presentation/Diary/DiaryViewerViewController.swift
@@ -67,6 +67,7 @@ class DiaryViewerViewController: UIViewController, PopUpProtocol, ToastProtocol 
         let label = UILabel()
         label.font = .regularTitle15
         label.textColor = .slate600
+        label.numberOfLines = 0
         
         return label
     }()


### PR DESCRIPTION
## 📚 작업한 일
- 일기 생성시 오류 수정
- 생성 완료 toast alert 띄우기

## 🔥 트러블 슈팅
### reducer State를 재활용하며 생긴 문제
DiaryReducer 내부의 reduce에서 기존 state를 새로운 state에 그대로 할당해 조금씩만 변경하게 하면서 문제가 생겼다. 
MVI 에서 Side Effect를 발생시키지 않으려면 state가 항상 새롭게 되어야 하는데, 그러지 못하다 보니 diffable에서 id 값이 두개라고 또 띄우고 있었다. 기존 State가 필요한 경우를 제외하고는 무조건 새롭게 생성하도록 변경하여 해결하였다. 
